### PR TITLE
Fix missing parentheses in deferred response body closing

### DIFF
--- a/internal/provider/containers_service_resource.go
+++ b/internal/provider/containers_service_resource.go
@@ -189,7 +189,7 @@ func (d *containersServiceResource) Create(ctx context.Context, req resource.Cre
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create service, got error: %s", err))
 		return
 	}
-	defer deferredCloseResponseBody(ctx, res.Body)
+	defer deferredCloseResponseBody(ctx, res.Body)()
 
 	resp_body, err := io.ReadAll(res.Body)
 	if err != nil {
@@ -259,7 +259,7 @@ func (d *containersServiceResource) Read(ctx context.Context, req resource.ReadR
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read service, got error: %s", err))
 		return
 	}
-	defer deferredCloseResponseBody(ctx, response.Body)
+	defer deferredCloseResponseBody(ctx, response.Body)()
 
 	body, err := io.ReadAll(response.Body)
 	if err != nil {
@@ -398,7 +398,7 @@ func (d *containersServiceResource) Update(ctx context.Context, req resource.Upd
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update service, got error: %s", err))
 		return
 	}
-	defer deferredCloseResponseBody(ctx, res.Body)
+	defer deferredCloseResponseBody(ctx, res.Body)()
 
 	if res.StatusCode != http.StatusOK {
 		resp.Diagnostics.AddError("API Error", fmt.Sprintf("Unable to update service, status code: %d", res.StatusCode))
@@ -465,7 +465,7 @@ func (d *containersServiceResource) Delete(ctx context.Context, req resource.Del
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete service, got error: %s", err))
 		return
 	}
-	defer deferredCloseResponseBody(ctx, response.Body)
+	defer deferredCloseResponseBody(ctx, response.Body)()
 
 	if response.StatusCode == http.StatusNotFound {
 		return


### PR DESCRIPTION
Add missing function call parentheses to `defer deferredCloseResponseBody` calls to prevent HTTP response body resource leaks.

---

[Open in Web](https://www.cursor.com/agents?id=bc-8e3bc7db-88fa-48bf-ab3d-20ac1577a4b6) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-8e3bc7db-88fa-48bf-ab3d-20ac1577a4b6)